### PR TITLE
Install: Move into /usr/local/bin/

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,7 @@
-
 #!/usr/bin/env bash
 
 wget https://raw.githubusercontent.com/dylanaraps/pfetch/master/pfetch
 
 chmod +x pfetch
 
-mv pfetch /usr/bin
+mv pfetch /usr/local/bin


### PR DESCRIPTION
Pfetch should be installed in /usr/local/bin for simplicity (because it isn't managed by PM)